### PR TITLE
feat: cambiar estado de recursos a ASIGNADO inmediatamente al crear s…

### DIFF
--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -669,40 +669,15 @@ export class ServicesService {
       throw new BadRequestException(
         'Para cambiar un servicio a estado INCOMPLETO, debe proporcionar un comentario explicando el motivo',
       );
-    }
-
-    // Al iniciar servicio
+    }    // Al iniciar servicio
     if (nuevoEstado === ServiceState.EN_PROGRESO) {
       if (!service.fechaInicio) {
         service.fechaInicio = new Date();
       }
 
-      // Cambiar estado recursos asignados a ASIGNADO
-      const assignments = await this.assignmentRepository.find({
-        where: { servicio: { id: service.id } },
-        relations: ['empleado', 'vehiculo', 'bano'],
-      });
-
-      for (const assignment of assignments) {
-        if (assignment.empleado) {
-          await this.employeesService.update(assignment.empleado.id, {
-            estado: ResourceState.ASIGNADO,
-          });
-        }
-        if (assignment.vehiculo) {
-          await this.vehiclesService.update(assignment.vehiculo.id, {
-            estado: ResourceState.ASIGNADO,
-          });
-        }
-        if (
-          assignment.bano &&
-          !service.banosInstalados?.includes(assignment.bano.baño_id)
-        ) {
-          await this.toiletsService.update(assignment.bano.baño_id, {
-            estado: ResourceState.ASIGNADO,
-          });
-        }
-      }
+      // Los recursos ya están en estado ASIGNADO desde la creación del servicio
+      // Ya no es necesario cambiar su estado aquí
+      this.logger.log('Servicio iniciado - Los recursos ya están en estado ASIGNADO');
     }
 
     // Al completar servicio
@@ -966,63 +941,50 @@ export class ServicesService {
           }
         }
       }
-    }
-    console.log('Total de asignaciones a guardar:', assignments.length);
+    }    console.log('Total de asignaciones a guardar:', assignments.length);
     const saved = await manager.save(assignments);
     console.log('Asignaciones guardadas:', saved.length);
 
-    // Obtener el servicio para verificar su estado
-    const service = await manager.findOne(Service, {
-      where: { id: serviceId },
-      select: ['id', 'estado'],
-    });
+    // Actualizar estados de recursos a ASIGNADO inmediatamente al crear las asignaciones
+    console.log(
+      'Actualizando estados de recursos a ASIGNADO tras crear las asignaciones',
+    );
 
-    // Solo actualizar estados de recursos si el servicio está EN_PROGRESO
-    if (service?.estado === ServiceState.EN_PROGRESO) {
-      console.log(
-        'Servicio EN_PROGRESO - Actualizando estados de recursos a ASIGNADO',
+    // Actualizar estados de empleados únicos
+    const empleadosIds = Array.from(empleadosProcesados);
+    if (empleadosIds.length > 0) {
+      await manager.update(
+        'empleados',
+        { id: In(empleadosIds) },
+        { estado: ResourceState.ASIGNADO },
       );
-
-      // Actualizar estados de empleados únicos
-      const empleadosIds = Array.from(empleadosProcesados);
-      if (empleadosIds.length > 0) {
-        await manager.update(
-          'empleados',
-          { id: In(empleadosIds) },
-          { estado: ResourceState.ASIGNADO },
-        );
-        console.log(
-          `Estados actualizados para empleados: ${empleadosIds.join(', ')}`,
-        );
-      }
-
-      // Actualizar estados de vehículos únicos
-      const vehiculosIds = Array.from(vehiculosProcesados);
-      if (vehiculosIds.length > 0) {
-        await manager.update(
-          'vehicles',
-          { id: In(vehiculosIds) },
-          { estado: ResourceState.ASIGNADO },
-        );
-        console.log(
-          `Estados actualizados para vehículos: ${vehiculosIds.join(', ')}`,
-        );
-      }
-
-      // Actualizar estados de baños únicos
-      const banosIds = Array.from(banosProcesados);
-      if (banosIds.length > 0) {
-        await manager.update(
-          'chemical_toilets',
-          { baño_id: In(banosIds) },
-          { estado: ResourceState.ASIGNADO },
-        );
-        console.log(`Estados actualizados para baños: ${banosIds.join(', ')}`);
-      }
-    } else {
       console.log(
-        `Servicio en estado ${service?.estado} - No se actualizan estados de recursos`,
+        `Estados actualizados para empleados: ${empleadosIds.join(', ')}`,
       );
+    }
+
+    // Actualizar estados de vehículos únicos
+    const vehiculosIds = Array.from(vehiculosProcesados);
+    if (vehiculosIds.length > 0) {
+      await manager.update(
+        'vehicles',
+        { id: In(vehiculosIds) },
+        { estado: ResourceState.ASIGNADO },
+      );
+      console.log(
+        `Estados actualizados para vehículos: ${vehiculosIds.join(', ')}`,
+      );
+    }
+
+    // Actualizar estados de baños únicos
+    const banosIds = Array.from(banosProcesados);
+    if (banosIds.length > 0) {
+      await manager.update(
+        'chemical_toilets',
+        { baño_id: In(banosIds) },
+        { estado: ResourceState.ASIGNADO },
+      );
+      console.log(`Estados actualizados para baños: ${banosIds.join(', ')}`);
     }
 
     console.log('--- Fin assignResourcesManually ---');


### PR DESCRIPTION
…ervicio

- Modificado assignResourcesManually para actualizar estados de recursos a ASIGNADO al crear asignaciones
- Eliminada lógica redundante en changeStatus que cambiaba estados cuando servicio pasa a EN_PROGRESO
- Los recursos (empleados, vehículos, baños) ahora se marcan como ASIGNADO desde la creación del servicio
- Mejora la consistencia del sistema evitando conflictos de disponibilidad