### PR TITLE
fix: Actualizar validación y estructura CBU a 22 dígitos

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "deploy:https": "bash scripts/deploy-https.sh",
     "seed:clients": "ts-node -r tsconfig-paths/register src/scripts/seed-clients.ts",
     "seed:test-data": "ts-node -r tsconfig-paths/register src/scripts/seed-test-data.ts",
-    "seed:admin": "ts-node -r tsconfig-paths/register src/scripts/create-admin-standalone.ts"
+    "seed:admin": "ts-node -r tsconfig-paths/register src/scripts/create-admin-standalone.ts",
+    "migrate:cbu": "ts-node -r tsconfig-paths/register src/scripts/migrate-cbu-length.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/employees/dto/create_employee.dto.ts
+++ b/src/employees/dto/create_employee.dto.ts
@@ -80,7 +80,7 @@ export class CreateEmployeeDto {
 
   @IsNotEmpty()
   @IsString()
-  @Length(11, 20, { message: 'El CBU debe tener entre 11 y 20 caracteres' })
+  @Length(22, 22, { message: 'El CBU debe tener exactamente 22 dígitos' })
   cbu: string;
 }
 

--- a/src/employees/dto/update_employee.dto.ts
+++ b/src/employees/dto/update_employee.dto.ts
@@ -79,7 +79,7 @@ export class UpdateEmployeeDto {
 
   @IsOptional()
   @IsString()
-  @Length(11, 20, { message: 'El CBU debe tener entre 11 y 20 caracteres' })
+  @Length(22, 22, { message: 'El CBU debe tener exactamente 22 dígitos' })
   cbu?: string;
 
   @IsOptional()

--- a/src/employees/entities/employee.entity.ts
+++ b/src/employees/entities/employee.entity.ts
@@ -58,7 +58,7 @@ export class Empleado {
   @Column({ name: 'CUIL', length: 20, unique: true, nullable: true })
   cuil: string;
 
-  @Column({ name: 'CBU', length: 20, unique: true, nullable: true })
+  @Column({ name: 'CBU', length: 22, unique: true, nullable: true })
   cbu: string;
 
   @OneToMany(() => ContactosEmergencia, (contact) => contact.empleado, {

--- a/src/scripts/migrate-cbu-length.sql
+++ b/src/scripts/migrate-cbu-length.sql
@@ -1,0 +1,18 @@
+-- Migración para actualizar la longitud del campo CBU de 20 a 22 caracteres
+-- Fecha: 2025-06-23
+-- Descripción: El CBU en Argentina debe tener exactamente 22 dígitos
+
+BEGIN;
+
+-- Alterar la columna CBU para aumentar su longitud de 20 a 22 caracteres
+ALTER TABLE employees 
+ALTER COLUMN "CBU" TYPE VARCHAR(22);
+
+-- Verificar que el cambio se aplicó correctamente
+-- Esta consulta debe devolver 22
+SELECT character_maximum_length 
+FROM information_schema.columns 
+WHERE table_name = 'employees' 
+AND column_name = 'CBU';
+
+COMMIT;

--- a/src/scripts/migrate-cbu-length.ts
+++ b/src/scripts/migrate-cbu-length.ts
@@ -1,0 +1,69 @@
+import { DataSource } from 'typeorm';
+import { config } from 'dotenv';
+
+// Cargar variables de entorno
+config();
+
+async function migrateCbuLength() {
+  const dataSource = new DataSource({
+    type: 'postgres',
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432'),
+    username: process.env.DB_USERNAME || 'postgres',
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE || 'mva_db',
+    synchronize: false,
+    logging: true,
+  });
+
+  try {
+    await dataSource.initialize();
+    console.log('📊 Conexión a la base de datos establecida');
+
+    // Ejecutar la migración
+    console.log('🔄 Iniciando migración para actualizar longitud del campo CBU...');
+    
+    await dataSource.query(`
+      ALTER TABLE employees 
+      ALTER COLUMN "CBU" TYPE VARCHAR(22);
+    `);
+
+    console.log('✅ Campo CBU actualizado a 22 caracteres');
+
+    // Verificar el cambio
+    const result = await dataSource.query(`
+      SELECT character_maximum_length 
+      FROM information_schema.columns 
+      WHERE table_name = 'employees' 
+      AND column_name = 'CBU';
+    `);
+
+    if (result[0]?.character_maximum_length === 22) {
+      console.log('✅ Verificación exitosa: El campo CBU ahora acepta 22 caracteres');
+    } else {
+      console.log('❌ Error en la verificación. Longitud actual:', result[0]?.character_maximum_length);
+    }
+
+  } catch (error) {
+    console.error('❌ Error durante la migración:', error);
+    throw error;
+  } finally {
+    await dataSource.destroy();
+    console.log('🔐 Conexión cerrada');
+  }
+}
+
+// Ejecutar la migración si se llama directamente
+if (require.main === module) {
+  migrateCbuLength()
+    .then(() => {
+      console.log('🎉 Migración completada exitosamente');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('💥 Error en la migración:', error);
+      process.exit(1);
+    });
+}
+
+export { migrateCbuLength };


### PR DESCRIPTION
- Actualizar DTOs de empleados para validar CBU con exactamente 22 dígitos
- Modificar entidad Employee para aumentar longitud de columna CBU a 22
- Agregar script de migración SQL para actualizar base de datos existente
- Agregar script Node.js para ejecutar migración programáticamente
- Incluir nuevo comando npm 'migrate:cbu' para ejecutar migración
- Cumplir con estándar argentino de CBU (22 dígitos exactos)