### PR TITLE
Mostrar código interno en emails de asignación de servicios de limpieza

### DIFF
--- a/src/mailer/mailer.module.ts
+++ b/src/mailer/mailer.module.ts
@@ -4,9 +4,10 @@ import { MailerService } from './mailer.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/users/entities/user.entity';
 import { Licencias } from 'src/employees/entities/license.entity';
+import { ChemicalToilet } from 'src/chemical_toilets/entities/chemical_toilet.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Licencias])],
+  imports: [TypeOrmModule.forFeature([User, Licencias, ChemicalToilet])],
   providers: [MailerService],
   exports: [MailerService],
 })

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -163,6 +163,12 @@ export class ServicesService {
 
       if (ultimoServicioInstalacion?.banosInstalados?.length) {
         service.banosInstalados = ultimoServicioInstalacion.banosInstalados;
+        
+        // Guardar los baños asignados en la base de datos
+        await this.serviceRepository.save(service);
+        this.logger.log(
+          `Baños asignados automáticamente al servicio de limpieza ${service.id}: ${service.banosInstalados.join(', ')}`,
+        );
       } else {
         this.logger.warn(
           `No se encontraron baños instalados para cliente ${dto.clienteId}`,


### PR DESCRIPTION
- Modificado createLimpieza para asignar baños instalados automáticamente
- Agregados logs de debug en mailer.interceptor.ts para diagnosticar emails
- Importado ChemicalToilet en mailer.module.ts para futuras mejoras