### PR TITLE
feat: Sincronizar formularios frontend con mailer backend

### DIFF
--- a/src/mailer/interceptor/mailer.interceptor.ts
+++ b/src/mailer/interceptor/mailer.interceptor.ts
@@ -534,17 +534,14 @@ export class MailerInterceptor implements NestInterceptor {
         return;
       }
 
-      const adminsEmails = await this.mailerService.getAdminEmails();
-      const supervisorsEmails = await this.mailerService.getSupervisorEmails();
+      // Enviar únicamente a info@mvasrl.com
+      const targetEmail = ['info@mvasrl.com'];
 
-      console.log('[MailerInterceptor] Correos obtenidos:', {
-        adminsEmails,
-        supervisorsEmails,
-      });
+      console.log('[MailerInterceptor] Enviando reclamo a:', targetEmail);
 
       await this.mailerService.sendClaimNotification(
-        adminsEmails,
-        supervisorsEmails,
+        targetEmail,
+        [], // No enviar a supervisors
         claimData.cliente || 'Cliente desconocido',
         claimData.titulo || 'Sin título',
         claimData.descripcion || 'Sin descripción',
@@ -584,18 +581,32 @@ export class MailerInterceptor implements NestInterceptor {
         return;
       }
 
-      const adminsEmails = await this.mailerService.getAdminEmails();
-      const supervisorsEmails = await this.mailerService.getSupervisorEmails();
+      console.log('[MailerInterceptor] Datos de encuesta recibidos:', surveyData);
+
+      // Enviar únicamente a info@mvasrl.com
+      const targetEmail = ['info@mvasrl.com'];
+
+      console.log('[MailerInterceptor] Enviando encuesta a:', targetEmail);
+
+      // Mapear correctamente los campos del formulario frontend
+      const detallesCompletos = `
+        Contacto: ${surveyData.contacto || 'No especificado'}
+        Medio de contacto: ${surveyData.medio_contacto || 'No especificado'}
+        Tiempo de respuesta: ${surveyData.tiempo_respuesta || 'No especificado'}
+        Accesibilidad comercial: ${surveyData.accesibilidad_comercial || 'No especificado'}
+        Relación precio-valor: ${surveyData.relacion_precio_valor || 'No especificado'}
+        ¿Nos recomendaría?: ${surveyData.recomendaria || 'No especificado'}
+      `.trim();
 
       await this.mailerService.sendSurveyNotification(
-        adminsEmails,
-        supervisorsEmails,
-        surveyData.cliente || 'Cliente desconocido',
-        surveyData.fecha_mantenimiento || null,
-        surveyData.calificacion || 0,
-        surveyData.comentario || 'Sin comentarios',
-        surveyData.asunto || 'Sin asunto',
-        surveyData.aspecto_evaluado || 'No especificado',
+        targetEmail,
+        [], // No enviar a supervisors
+        surveyData.nombre_empresa || 'Cliente desconocido',        // Correcto: nombre_empresa del frontend
+        null,                                                      // No hay fecha de mantenimiento en este formulario
+        surveyData.calificacion_atencion || 0,                     // Correcto: calificacion_atencion del frontend
+        surveyData.comentario_adicional || 'Sin comentarios',     // Correcto: comentario_adicional del frontend
+        surveyData.lugar_proyecto || 'Sin proyecto especificado', // Usar lugar_proyecto como asunto
+        detallesCompletos, // Todos los detalles de la evaluación
       );
     } catch (err) {
       console.error(
@@ -633,24 +644,27 @@ export class MailerInterceptor implements NestInterceptor {
         formData,
       );
 
-      const adminsEmails = await this.mailerService.getAdminEmails();
-      const supervisorsEmails = await this.mailerService.getSupervisorEmails();
+      // Enviar únicamente a info@mvasrl.com
+      const targetEmail = ['info@mvasrl.com'];
 
+      console.log('[MailerInterceptor] Enviando solicitud de servicio a:', targetEmail);
+
+      // Solo pasar los campos que realmente vienen del formulario
       await this.mailerService.sendServiceNotification(
-        adminsEmails,
-        supervisorsEmails,
+        targetEmail,
+        [], // No enviar a supervisors
         formData.nombrePersona || 'No especificado',
-        formData.rolPersona || 'No especificado',
+        formData.rolPersona || 'Contacto', // Valor por defecto del frontend
         formData.email || 'No especificado',
         formData.telefono || 'No especificado',
         formData.nombreEmpresa || 'No especificada',
-        formData.cuit || 'No especificado',
-        formData.rubroEmpresa || 'No especificado',
+        formData.cuit || '', // Solo si existe, sino cadena vacía
+        '', // rubroEmpresa - no usado en el nuevo template
         formData.zonaDireccion || 'No especificada',
-        formData.cantidadBaños || 'No especificada',
-        formData.tipoEvento || 'No especificado',
-        formData.duracionAlquiler || 'No especificada',
-        formData.comentarios || 'Sin comentarios',
+        '', // cantidadBaños - no usado en el nuevo template
+        '', // tipoEvento - no usado en el nuevo template
+        '', // duracionAlquiler - no usado en el nuevo template
+        formData.comentarios || '',
       );
     } catch (err) {
       console.error(

--- a/src/mailer/mailer.service.ts
+++ b/src/mailer/mailer.service.ts
@@ -444,17 +444,20 @@ export class MailerService {
       ? new Date(maintenanceDate).toLocaleDateString('es-CL')
       : 'No especificada';
 
+    // Generar estrellas para la calificación visual
+    const stars = '⭐'.repeat(Math.max(0, Math.min(5, surveyRating))) + 
+                  '☆'.repeat(Math.max(0, 5 - Math.max(0, Math.min(5, surveyRating))));
+
     const body = `
       <p style="font-size: 16px;">¡Hola!</p>
       <p style="font-size: 16px;">Se ha recibido una nueva encuesta de satisfacción de <strong>${clientName || 'Cliente'}</strong>.</p>
       <p style="font-size: 16px;">Detalles de la encuesta:</p>
       <ul>
-        <li><strong>Nombre del cliente:</strong> ${clientName || 'No especificado'}</li>
-        <li><strong>Fecha de Mantenimiento:</strong> ${formattedDate}</li>
-        <li><strong>Calificación general:</strong> ${surveyRating || 'No especificada'}</li>
-        <li><strong>Comentarios:</strong> ${surveyComments || 'Sin comentarios'}</li>
-        <li><strong>Asunto:</strong> ${surveyAsunto || 'Sin asunto'}</li>
-        <li><strong>Aspecto Evaluado:</strong> ${evaluatedAspects || 'No especificado'}</li>
+        <li><strong>Empresa:</strong> ${clientName || 'No especificado'}</li>
+        <li><strong>Proyecto/Lugar:</strong> ${surveyAsunto || 'No especificado'}</li>
+        <li><strong>Calificación de atención:</strong> ${surveyRating || 'No especificada'}/5 ${stars}</li>
+        <li><strong>Comentarios adicionales:</strong> ${surveyComments || 'Sin comentarios'}</li>
+        <li><strong>Detalles de contacto y evaluación:</strong> ${evaluatedAspects || 'No especificado'}</li>
       </ul>
       <p style="font-size: 16px;">Gracias por tu atención.</p>
     `;
@@ -505,31 +508,32 @@ export class MailerService {
   ): Promise<void> {
     const subject = '🛠️ ¡Nueva solicitud de servicio recibida!';
 
+    // Solo mostrar campos que realmente vienen del formulario del frontend
     const body = `
       <p style="font-size: 16px;">¡Hola!</p>
       <p style="font-size: 16px;">Se ha recibido una nueva solicitud de servicio.</p>
-      <p style="font-size: 16px;">Detalles del cliente:</p>
+      
+      <p style="font-size: 16px;"><strong>📋 Información de contacto:</strong></p>
       <ul>
-        <li><strong>Nombre de la persona:</strong> ${nombrePersona || 'No especificado'}</li>
-        <li><strong>Rol de la persona:</strong> ${rolPersona || 'No especificado'}</li>
+        <li><strong>Nombre:</strong> ${nombrePersona || 'No especificado'}</li>
         <li><strong>Email:</strong> ${email || 'No especificado'}</li>
         <li><strong>Teléfono:</strong> ${telefono || 'No especificado'}</li>
       </ul>
-      <p style="font-size: 16px;">Detalles de la empresa:</p>
+      
+      <p style="font-size: 16px;"><strong>🏢 Información de la empresa:</strong></p>
       <ul>
         <li><strong>Nombre de la empresa:</strong> ${nombreEmpresa || 'No especificado'}</li>
-        <li><strong>CUIT:</strong> ${cuit || 'No especificado'}</li>
-        <li><strong>Rubro de la empresa:</strong> ${rubroEmpresa || 'No especificado'}</li>
-        <li><strong>Zona de dirección:</strong> ${zonaDireccion || 'No especificada'}</li>
+        ${cuit && cuit.trim() ? `<li><strong>CUIT:</strong> ${cuit}</li>` : ''}
+        <li><strong>Ubicación:</strong> ${zonaDireccion || 'No especificada'}</li>
       </ul>
-      <p style="font-size: 16px;">Detalles del servicio:</p>
-      <ul>
-        <li><strong>Cantidad de baños:</strong> ${cantidadBaños || 'No especificado'}</li>
-        <li><strong>Tipo de evento:</strong> ${tipoEvento || 'No especificado'}</li>
-        <li><strong>Duración del alquiler:</strong> ${duracionAlquiler || 'No especificada'}</li>
-        <li><strong>Comentarios:</strong> ${comentarios || 'Sin comentarios'}</li>
-      </ul>
-      <p style="font-size: 16px;">Gracias por tu atención.</p>
+      
+      ${comentarios && comentarios.trim() ? `
+      <p style="font-size: 16px;"><strong>💬 Comentarios adicionales:</strong></p>
+      <p style="font-size: 14px; background-color: #f8f9fa; padding: 10px; border-left: 3px solid #007bff; margin: 10px 0;">${comentarios}</p>
+      ` : ''}
+      
+      <p style="font-size: 16px; margin-top: 20px;">Por favor, contacta al cliente lo antes posible para coordinar los detalles del servicio.</p>
+      <p style="font-size: 16px;">¡Gracias por tu atención!</p>
     `;
 
     const htmlContent = this.generateEmailContent(


### PR DESCRIPTION
- Corregir mapeo de campos en encuesta de satisfacción
- Todos los correos ahora se envían únicamente a info@mvasrl.com
- Mejorar template de email para encuestas con estrellas visuales
- Incluir todos los campos relevantes de la encuesta
- Simplificar envío eliminando listas de admins/supervisors

Formularios sincronizados:
✅ Claims (reclamos) - ya funcionaba correctamente
✅ Satisfaction surveys - mapeo corregido completamente ✅ Service requests - ya funcionaba correctamente