### PR TITLE
fix: Corregir duplicación de alertas de licencias próximas a vencer

### DIFF
--- a/src/scheduler/scheduler.module.ts
+++ b/src/scheduler/scheduler.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Service } from '../services/entities/service.entity';
@@ -6,15 +6,34 @@ import { ChemicalToilet } from '../chemical_toilets/entities/chemical_toilet.ent
 import { ContractExpirationService } from './services/contract-expiration.service';
 import { EmployeeLeaveSchedulerService } from './services/employee-leave-scheduler.service';
 import { EmployeeLeave } from '../employee_leaves/entities/employee-leave.entity';
-import { EmployeesModule } from '../employees/employees.module';
+import { EmployeesService } from '../employees/employees.service';
+import { Empleado } from '../employees/entities/employee.entity';
+import { Licencias } from '../employees/entities/license.entity';
+import { ContactosEmergencia } from '../employees/entities/emergencyContacts.entity';
+import { ExamenPreocupacional } from '../employees/entities/examenPreocupacional.entity';
+import { RolesModule } from '../roles/roles.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
-    TypeOrmModule.forFeature([Service, ChemicalToilet, EmployeeLeave]),
-    EmployeesModule,
+    TypeOrmModule.forFeature([
+      Service, 
+      ChemicalToilet, 
+      EmployeeLeave, 
+      Empleado,
+      Licencias,
+      ContactosEmergencia,
+      ExamenPreocupacional
+    ]),
+    RolesModule,
+    forwardRef(() => UsersModule),
   ],
-  providers: [ContractExpirationService, EmployeeLeaveSchedulerService],
+  providers: [
+    ContractExpirationService, 
+    EmployeeLeaveSchedulerService,
+    EmployeesService, // Solo EmployeesService, NO LicenseAlertService
+  ],
   exports: [ContractExpirationService, EmployeeLeaveSchedulerService],
 })
 export class SchedulerModule {}


### PR DESCRIPTION
Problema:
- Las alertas de licencias se enviaban duplicadas porque LicenseAlertService se registraba múltiples veces en diferentes módulos
- EmployeesModule se importaba en app.module.ts Y en scheduler.module.ts
- Esto causaba que el @Cron job se programara dos veces

Solución:
- Remover EmployeesModule del SchedulerModule
- Importar solo EmployeesService directamente con sus dependencias
- Mantener LicenseAlertService únicamente en EmployeesModule

Resultado:
- Alertas de licencia se envían una sola vez
- No más duplicación de correos electrónicos
- Arquitectura de módulos más limpia